### PR TITLE
Update directional tint to godot 4.3

### DIFF
--- a/godot/Demos/UnlitDirectionalTint.tscn
+++ b/godot/Demos/UnlitDirectionalTint.tscn
@@ -1,10 +1,79 @@
-[gd_scene load_steps=7 format=3 uid="uid://belth5nhg7do1"]
+[gd_scene load_steps=9 format=3 uid="uid://belth5nhg7do1"]
 
 [ext_resource type="PackedScene" uid="uid://c0vr8gmnaba4r" path="res://Shared/models/3D-environment/ShockwaveScene.glb" id="1"]
-[ext_resource type="Material" path="res://Demos/UnlitDirectionalTint/UnlitDirectionalTint.tres" id="2"]
-[ext_resource type="PackedScene" path="res://Shared/DemoInterface.tscn" id="3"]
-[ext_resource type="PackedScene" path="res://Shared/Demo3DEnvironment.tscn" id="4"]
+[ext_resource type="Material" uid="uid://b728wkr1lafxb" path="res://Demos/UnlitDirectionalTint/UnlitDirectionalTint.tres" id="2"]
+[ext_resource type="PackedScene" uid="uid://diofpwcvq5elu" path="res://Shared/DemoInterface.tscn" id="3"]
+[ext_resource type="PackedScene" uid="uid://dquhei2qv5csj" path="res://Shared/Demo3DEnvironment.tscn" id="4"]
 [ext_resource type="Script" path="res://addons/ShaderSecretsHelper/DemoScreen.gd" id="5"]
+
+[sub_resource type="Animation" id="Animation_4peom"]
+length = 0.001
+tracks/0/type = "bezier"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath("ShockwaveScene2:rotation_degrees:y")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
+}
+tracks/1/type = "bezier"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath("ShockwaveScene2:rotation_degrees:x")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
+}
+tracks/2/type = "bezier"
+tracks/2/imported = false
+tracks/2/enabled = true
+tracks/2/path = NodePath("ShockwaveScene2:rotation_degrees:z")
+tracks/2/interp = 1
+tracks/2/loop_wrap = true
+tracks/2/keys = {
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
+}
+tracks/3/type = "bezier"
+tracks/3/imported = false
+tracks/3/enabled = true
+tracks/3/path = NodePath("ShockwaveScene:rotation_degrees:x")
+tracks/3/interp = 1
+tracks/3/loop_wrap = true
+tracks/3/keys = {
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
+}
+tracks/4/type = "bezier"
+tracks/4/imported = false
+tracks/4/enabled = true
+tracks/4/path = NodePath("ShockwaveScene:rotation_degrees:y")
+tracks/4/interp = 1
+tracks/4/loop_wrap = true
+tracks/4/keys = {
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
+}
+tracks/5/type = "bezier"
+tracks/5/imported = false
+tracks/5/enabled = true
+tracks/5/path = NodePath("ShockwaveScene:rotation_degrees:z")
+tracks/5/interp = 1
+tracks/5/loop_wrap = true
+tracks/5/keys = {
+"handle_modes": PackedInt32Array(0),
+"points": PackedFloat32Array(0, -0.25, 0, 0.25, 0),
+"times": PackedFloat32Array(0)
+}
 
 [sub_resource type="Animation" id="1"]
 resource_name = "show"
@@ -17,9 +86,9 @@ tracks/0/path = NodePath("ShockwaveScene2:rotation_degrees:x")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"handle_modes": PackedInt32Array(),
-"points": PackedFloat32Array(),
-"times": PackedFloat32Array()
+"handle_modes": PackedInt32Array(2, 2),
+"points": PackedFloat32Array(0, 0, 0, 1.66667, 0, 0, -1.66667, 0, 0, 0),
+"times": PackedFloat32Array(0, 5)
 }
 tracks/1/type = "bezier"
 tracks/1/imported = false
@@ -28,9 +97,9 @@ tracks/1/path = NodePath("ShockwaveScene2:rotation_degrees:y")
 tracks/1/interp = 1
 tracks/1/loop_wrap = true
 tracks/1/keys = {
-"handle_modes": PackedInt32Array(),
-"points": PackedFloat32Array(),
-"times": PackedFloat32Array()
+"handle_modes": PackedInt32Array(2, 2, 2, 2, 2),
+"points": PackedFloat32Array(0, 0, 0, 0.5, 0, 90, -0.5, 0, 0.333333, 0, 90, -0.333333, 0, 0.5, 0, 0, -0.5, 0, 0.333333, 0, 0, -0.333333, 0, 0, 0),
+"times": PackedFloat32Array(0, 1.5, 2.5, 4, 5)
 }
 tracks/2/type = "bezier"
 tracks/2/imported = false
@@ -39,9 +108,9 @@ tracks/2/path = NodePath("ShockwaveScene2:rotation_degrees:z")
 tracks/2/interp = 1
 tracks/2/loop_wrap = true
 tracks/2/keys = {
-"handle_modes": PackedInt32Array(),
-"points": PackedFloat32Array(),
-"times": PackedFloat32Array()
+"handle_modes": PackedInt32Array(2, 2),
+"points": PackedFloat32Array(0, 0, 0, 1.66667, 0, 0, -1.66667, 0, 0, 0),
+"times": PackedFloat32Array(0, 5)
 }
 tracks/3/type = "bezier"
 tracks/3/imported = false
@@ -50,9 +119,9 @@ tracks/3/path = NodePath("ShockwaveScene:rotation_degrees:x")
 tracks/3/interp = 1
 tracks/3/loop_wrap = true
 tracks/3/keys = {
-"handle_modes": PackedInt32Array(),
-"points": PackedFloat32Array(),
-"times": PackedFloat32Array()
+"handle_modes": PackedInt32Array(2, 2),
+"points": PackedFloat32Array(0, 0, 0, 1.66667, 0, 0, -1.66667, 0, 0, 0),
+"times": PackedFloat32Array(0, 5)
 }
 tracks/4/type = "bezier"
 tracks/4/imported = false
@@ -61,9 +130,9 @@ tracks/4/path = NodePath("ShockwaveScene:rotation_degrees:y")
 tracks/4/interp = 1
 tracks/4/loop_wrap = true
 tracks/4/keys = {
-"handle_modes": PackedInt32Array(),
-"points": PackedFloat32Array(),
-"times": PackedFloat32Array()
+"handle_modes": PackedInt32Array(2, 2, 2, 2, 2),
+"points": PackedFloat32Array(0, 0, 0, 0.5, 0, 90, -0.5, 0, 0.333333, 0, 90, -0.333333, 0, 0.5, 0, 0, -0.5, 0, 0.333333, 0, 0, -0.333333, 0, 0, 0),
+"times": PackedFloat32Array(0, 1.5, 2.5, 4, 5)
 }
 tracks/5/type = "bezier"
 tracks/5/imported = false
@@ -72,9 +141,15 @@ tracks/5/path = NodePath("ShockwaveScene:rotation_degrees:z")
 tracks/5/interp = 1
 tracks/5/loop_wrap = true
 tracks/5/keys = {
-"handle_modes": PackedInt32Array(),
-"points": PackedFloat32Array(),
-"times": PackedFloat32Array()
+"handle_modes": PackedInt32Array(2, 2),
+"points": PackedFloat32Array(0, 0, 0, 1.66667, 0, 0, -1.66667, 0, 0, 0),
+"times": PackedFloat32Array(0, 5)
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_hujme"]
+_data = {
+"RESET": SubResource("Animation_4peom"),
+"show": SubResource("1")
 }
 
 [node name="UnlitDirectionalTintDemo" type="CanvasLayer"]
@@ -95,13 +170,13 @@ material_override = ExtResource("2")
 [node name="tree_forest" parent="ShockwaveScene" index="2"]
 material_override = ExtResource("2")
 
-[node name="detail_forest001" parent="ShockwaveScene" index="3"]
+[node name="detail_forest_001" parent="ShockwaveScene" index="3"]
 material_override = ExtResource("2")
 
-[node name="tree_forest001" parent="ShockwaveScene" index="4"]
+[node name="tree_forest_001" parent="ShockwaveScene" index="4"]
 material_override = ExtResource("2")
 
-[node name="tree_forest002" parent="ShockwaveScene" index="5"]
+[node name="tree_forest_002" parent="ShockwaveScene" index="5"]
 material_override = ExtResource("2")
 
 [node name="Demo3DEnvironment" parent="." instance=ExtResource("4")]
@@ -110,9 +185,12 @@ material_override = ExtResource("2")
 transform = Transform3D(1, 0, 0, 0, 0.970321, 0.24182, 0, -0.24182, 0.970321, 0, 5.79023, 12.0303)
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]
+libraries = {
+"": SubResource("AnimationLibrary_hujme")
+}
 autoplay = "show"
-anims/show = SubResource("1")
 
 [node name="DemoInterface" parent="." instance=ExtResource("3")]
+anchors_preset = 10
 
 [editable path="ShockwaveScene"]

--- a/godot/Demos/UnlitDirectionalTint/UnlitDirectionalTint.tres
+++ b/godot/Demos/UnlitDirectionalTint/UnlitDirectionalTint.tres
@@ -1,12 +1,13 @@
-[gd_resource type="ShaderMaterial" load_steps=3 format=2]
+[gd_resource type="ShaderMaterial" load_steps=3 format=3 uid="uid://b728wkr1lafxb"]
 
-[ext_resource path="res://Shaders/unlit_directional_tint.gdshader" type="Shader" id=1]
-[ext_resource path="res://Shared/models/3D-environment/SceneColorAtlas.tres" type="Texture2D" id=2]
+[ext_resource type="Shader" path="res://Shaders/unlit_directional_tint.gdshader" id="1"]
+[ext_resource type="Texture2D" uid="uid://dklympjuioh10" path="res://Shared/models/3D-environment/SceneColorAtlas.tres" id="2"]
 
 [resource]
-shader = ExtResource( 1 )
-shader_param/modulate_color = Color( 1, 1, 1, 1 )
-shader_param/colorA = Color( 0.815686, 0.823529, 0.980392, 1 )
-shader_param/colorB = Color( 0.411765, 0.588235, 0.92549, 1 )
-shader_param/colorC = Color( 0.741176, 0.898039, 0.913725, 1 )
-shader_param/color_texture = ExtResource( 2 )
+render_priority = 0
+shader = ExtResource("1")
+shader_parameter/tint_x = Color(0.4, 0.6, 0.8, 1)
+shader_parameter/tint_y = Color(0.9, 0.9, 0.9, 1)
+shader_parameter/tint_z = Color(0.6, 0.8, 0.7, 1)
+shader_parameter/overall_tint = Color(1, 1, 1, 1)
+shader_parameter/albedo_texture = ExtResource("2")

--- a/godot/Shaders/unlit_directional_tint.gdshader
+++ b/godot/Shaders/unlit_directional_tint.gdshader
@@ -2,31 +2,44 @@
 shader_type spatial;
 render_mode unshaded;
 
-uniform sampler2D color_texture: source_color;
+/** Albedo texture. Base color. */
+uniform sampler2D albedo_texture: source_color;
 
-uniform vec4 modulate_color : source_color = vec4(1.0);
-uniform vec4 colorA : source_color = vec4(1.0);
-uniform vec4 colorB : source_color = vec4(1.0);
-uniform vec4 colorC : source_color = vec4(1.0);
+/** The tint for the sides of the mesh, along the global x-axis.*/
+uniform vec4 tint_x : source_color = vec4(.4, 0.6, 0.8, 1.0);
+/** The tint for the top of the mesh, along the global y-axis.*/
+uniform vec4 tint_y : source_color =  vec4(0.9, 0.9, 0.9, 1.0);
+/** The tint for the sides of the mesh, along the global z-axis.*/
+uniform vec4 tint_z : source_color =  vec4(0.6, 0.8, 0.7, 1.0);
+/** Use this color to control the overall tint after tinting per-axis. */
+uniform vec4 overall_tint : source_color = vec4(1.0);
 
-varying vec3 color;
+varying vec4 tint;
 
 void vertex() {
 	// In this shader, we use the world normal to mix the tints of the object.
+	
+	// Transform the normal from model space to world space.
 	vec3 world_normal = (MODEL_MATRIX * vec4(NORMAL, 0.0)).xyz;
 	world_normal = normalize(world_normal);
-	// because we will use each component in a mix() function, we want to ensure
-	// that they will be positive. We could do abs(), but using pow also gives us
-	// a nice, non linear curve.
-	world_normal = pow(world_normal, vec3(2.0));
-	vec4 mod_x = modulate_color * colorA;
-	COLOR = mix(mix(mix(mod_x, modulate_color * colorB, world_normal.x), mod_x, world_normal.y),
-			modulate_color * colorC,
-			world_normal.z);
-	
-	color = world_normal;
+
+	// Because we will use each component in a mix() function, we want to ensure
+	// that they will be positive. We could use abs(), but using pow() also gives
+	// us a nice, non linear curve.
+
+	// Equivalent to pow(world_normal, vec3(2.0));
+	// But using pow() produces very bright glow in Forward+.
+	world_normal = world_normal * world_normal;
+
+	// Start with a neutral white, then mix in each world axis color.
+	tint = mix(vec4(1.0), tint_y, world_normal.y);
+	tint = mix(tint, tint_x, world_normal.x);
+	tint = mix(tint, tint_z, world_normal.z);
+	// Then, modulate by an overall tint.
+	// This will be passed along to the fragment shader.
+	tint = overall_tint * tint; 
 }
 
 void fragment() {
-	ALBEDO = COLOR.rgb * texture(color_texture, UV).rgb;
+	ALBEDO = tint.rgb * texture(albedo_texture, UV).rgb;
 }


### PR DESCRIPTION
- Comments for parameters.
- Simplify tinting math.
- Improve animation keyframes.
- Use a varying instead of the vertex color.
- Fix a pow() bug on forward+.