### PR TITLE
fix: perlin shader

### DIFF
--- a/godot/Demos/NoiseDemo.tscn
+++ b/godot/Demos/NoiseDemo.tscn
@@ -27,6 +27,7 @@ shader_parameter/layers = 3
 [sub_resource type="ShaderMaterial" id="3"]
 shader = ExtResource("3")
 shader_parameter/scale = Vector2(10, 10)
+shader_parameter/seamless = false
 shader_parameter/seed = 1
 
 [sub_resource type="ShaderMaterial" id="4"]

--- a/godot/Shaders/perlin_noise.gdshader
+++ b/godot/Shaders/perlin_noise.gdshader
@@ -2,9 +2,13 @@ shader_type canvas_item;
 
 uniform vec2 scale = vec2(10.0);
 uniform bool seamless = false;
+uniform int seed = 1;
 
-float rand(vec2 coord) {
-	return fract(sin(dot(coord, vec2(12.9898, 78.233))) * 43758.5453);
+// Generate a random value based on a 2D point and seed
+float rand(vec2 point) {
+    vec3 p3 = fract(vec3(point.xyx) * float(seed) * 1.031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
 }
 
 float perlin_noise(vec2 coord) {


### PR DESCRIPTION
Fixed perlin noise shader by changing to different rand function (same thing I did with value noise) and adding seed.

I have also noticed that perlin noise, along with some other ones have `seamless` shader parameter which currently does nothing. Worth checking out whether it is something we want to implement for all shaders, or just remove it as it currently does nothing. I think either option is fine, as long as there is consistency.

Other than that this is ready to be merged 👍🏽 