### PR TITLE
Fix clouds

### DIFF
--- a/godot/Demos/Clouds2DDemo.tscn
+++ b/godot/Demos/Clouds2DDemo.tscn
@@ -1,8 +1,9 @@
-[gd_scene load_steps=8 format=3 uid="uid://ctuwb82j6nkhi"]
+[gd_scene load_steps=9 format=3 uid="uid://ctuwb82j6nkhi"]
 
-[ext_resource type="Texture2D" path="res://Demos/Clouds2D/clouds_noise1.tres" id="1"]
+[ext_resource type="Texture2D" uid="uid://bok1i4hhop0o2" path="res://Demos/Clouds2D/clouds_noise1.tres" id="1"]
 [ext_resource type="Shader" path="res://Shaders/clouds2D.gdshader" id="2"]
-[ext_resource type="PackedScene" path="res://Shared/DemoInterface.tscn" id="3"]
+[ext_resource type="Texture2D" uid="uid://68d1kelgq6t5" path="res://Demos/Clouds2D/topdown-adventure.svg" id="2_hu7yr"]
+[ext_resource type="PackedScene" uid="uid://diofpwcvq5elu" path="res://Shared/DemoInterface.tscn" id="3"]
 [ext_resource type="Script" path="res://addons/ShaderSecretsHelper/DemoScreen.gd" id="5"]
 
 [sub_resource type="Gradient" id="1"]
@@ -26,10 +27,7 @@ shader_parameter/gradient_texture = SubResource("2")
 script = ExtResource("5")
 
 [node name="Background" type="TextureRect" parent="."]
-texture = null
-__meta__ = {
-"_edit_use_anchors_": false
-}
+texture = ExtResource("2_hu7yr")
 
 [node name="Clouds" type="Sprite2D" parent="."]
 material = SubResource("3")
@@ -38,4 +36,5 @@ scale = Vector2(1.8781, 2.12213)
 texture = ExtResource("1")
 
 [node name="DemoInterface" parent="." instance=ExtResource("3")]
+anchors_preset = 10
 offset_right = 0.00012207

--- a/godot/Demos/Clouds2DDemo.tscn
+++ b/godot/Demos/Clouds2DDemo.tscn
@@ -7,7 +7,8 @@
 [ext_resource type="Script" path="res://addons/ShaderSecretsHelper/DemoScreen.gd" id="5"]
 
 [sub_resource type="Gradient" id="1"]
-offsets = PackedFloat32Array(0.518987, 0.544304)
+interpolation_mode = 2
+offsets = PackedFloat32Array(0.4, 0.7)
 
 [sub_resource type="GradientTexture2D" id="2"]
 gradient = SubResource("1")
@@ -16,8 +17,8 @@ gradient = SubResource("1")
 shader = ExtResource("2")
 shader_parameter/tint = Color(0.0761719, 0.244629, 0.75, 0.541176)
 shader_parameter/scroll_direction_1 = Vector2(0.7, -0.7)
-shader_parameter/time_scale_1 = 0.012
-shader_parameter/tile_factor_1 = 0.6
+shader_parameter/time_scale_1 = 0.01
+shader_parameter/tile_factor_1 = 0.235
 shader_parameter/scroll_direction_2 = Vector2(0.75, 0.25)
 shader_parameter/time_scale_2 = 0.005
 shader_parameter/tile_factor_2 = 0.3
@@ -27,9 +28,16 @@ shader_parameter/gradient_texture = SubResource("2")
 script = ExtResource("5")
 
 [node name="Background" type="TextureRect" parent="."]
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 texture = ExtResource("2_hu7yr")
+expand_mode = 1
 
 [node name="Clouds" type="Sprite2D" parent="."]
+texture_repeat = 2
 material = SubResource("3")
 position = Vector2(960, 540)
 scale = Vector2(1.8781, 2.12213)

--- a/godot/Shaders/clouds2D.gdshader
+++ b/godot/Shaders/clouds2D.gdshader
@@ -19,10 +19,11 @@ uniform float tile_factor_2 : hint_range(0.1, 3.0) = 0.3;
 void fragment() {
 	vec2 noise_2_uv = UV * tile_factor_2 + scroll_direction_2 * TIME * time_scale_2;
 	float noise_2 = texture(noise_texture_2, noise_2_uv).r;
-	
+
 	vec2 noise_1_uv = UV * tile_factor_1 + scroll_direction_1 * TIME * time_scale_1;
 	float noise_1 = texture(TEXTURE, noise_1_uv + noise_2 * 0.02).r;
-	
+
 	float clouds = texture(gradient_texture, vec2(noise_1, 0.0)).r;
+
 	COLOR.rgb = mix(vec3(1.0), tint.rgb, clouds * tint.a);
 }


### PR DESCRIPTION
Per the [migration to Godot 4 tracker issue post ](https://github.com/gdquest-demos/godot-shaders/issues/53#issuecomment-2637610833) here is the fix for the clouds shader.

Issues found (and fixed):

- Background texture reference was wiped.
- Noise texture used to generate the clouds wasn't repeating.