### PR TITLE
Fix blur glow

### DIFF
--- a/godot/Demos/BlurGlowDemo.tscn
+++ b/godot/Demos/BlurGlowDemo.tscn
@@ -1,13 +1,14 @@
-[gd_scene load_steps=15 format=3 uid="uid://ci11oo63dcfuh"]
+[gd_scene load_steps=16 format=3 uid="uid://ci11oo63dcfuh"]
 
 [ext_resource type="Script" path="res://addons/ShaderSecretsHelper/DemoScreen.gd" id="1"]
 [ext_resource type="PackedScene" uid="uid://dnei3uy5bhpha" path="res://Demos/Glow2D/BlurGlow/Scene.tscn" id="2"]
 [ext_resource type="Shader" path="res://Shaders/gaussian_blur.gdshader" id="3"]
 [ext_resource type="Shader" path="res://Shaders/compose.gdshader" id="4"]
 [ext_resource type="Shader" path="res://Shaders/glow_prepass.gdshader" id="5"]
-[ext_resource type="PackedScene" path="res://Shared/Background2D/Demo2DBackground.tscn" id="7"]
+[ext_resource type="Texture2D" uid="uid://7giw201cbixu" path="res://Shared/sprites/robi_shaded.png" id="5_bxej1"]
+[ext_resource type="PackedScene" uid="uid://7mqdkojagyav" path="res://Shared/Background2D/Demo2DBackground.tscn" id="7"]
 [ext_resource type="Script" path="res://Utils/DebugViewer.gd" id="8"]
-[ext_resource type="PackedScene" path="res://Shared/DemoInterface.tscn" id="9"]
+[ext_resource type="PackedScene" uid="uid://diofpwcvq5elu" path="res://Shared/DemoInterface.tscn" id="9"]
 
 [sub_resource type="ShaderMaterial" id="1"]
 shader = ExtResource("3")
@@ -39,76 +40,64 @@ script = ExtResource("1")
 
 [node name="MaskView" type="SubViewportContainer" parent="."]
 self_modulate = Color(1, 1, 1, 0)
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
 stretch = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="SubViewport" type="SubViewport" parent="MaskView"]
-size = Vector2(1920, 1080)
 transparent_bg = true
 handle_input_locally = false
-usage = 0
-render_target_update_mode = 3
+size = Vector2i(1920, 1080)
+render_target_update_mode = 4
 
 [node name="Blur2" type="SubViewportContainer" parent="MaskView/SubViewport"]
 material = SubResource("1")
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
 stretch = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="SubViewport" type="SubViewport" parent="MaskView/SubViewport/Blur2"]
-size = Vector2(1920, 1080)
 transparent_bg = true
 handle_input_locally = false
-usage = 0
-render_target_update_mode = 3
+size = Vector2i(1920, 1080)
+render_target_update_mode = 4
 
 [node name="Blur1" type="SubViewportContainer" parent="MaskView/SubViewport/Blur2/SubViewport"]
 material = SubResource("2")
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
 stretch = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="SubViewport" type="SubViewport" parent="MaskView/SubViewport/Blur2/SubViewport/Blur1"]
-size = Vector2(1920, 1080)
 transparent_bg = true
 handle_input_locally = false
-usage = 0
-render_target_update_mode = 3
+size = Vector2i(1920, 1080)
+render_target_update_mode = 4
 
 [node name="Sprite2D" type="Sprite2D" parent="MaskView/SubViewport/Blur2/SubViewport/Blur1/SubViewport"]
 material = SubResource("3")
 position = Vector2(960, 540)
-texture = null
+texture = ExtResource("5_bxej1")
 
 [node name="MainView" type="SubViewportContainer" parent="."]
 material = SubResource("6")
+anchors_preset = 15
 anchor_right = 1.0
 anchor_bottom = 1.0
 mouse_filter = 2
 stretch = true
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="SubViewport" type="SubViewport" parent="MainView"]
-size = Vector2(1920, 1080)
 transparent_bg = true
 handle_input_locally = false
-usage = 0
-render_target_update_mode = 3
+size = Vector2i(1920, 1080)
+render_target_update_mode = 4
 
 [node name="Scene" parent="MainView/SubViewport" instance=ExtResource("2")]
 
@@ -120,14 +109,15 @@ scale = Vector2(1, 1)
 remote_path = NodePath("../../../../../MaskView/SubViewport/Blur2/SubViewport/Blur1/SubViewport/Sprite2D")
 
 [node name="DebugViewer" type="Control" parent="."]
+visible = false
+layout_mode = 3
+anchors_preset = 0
 offset_top = 120.0
 offset_right = 40.0
 offset_bottom = 160.0
 script = ExtResource("8")
-__meta__ = {
-"_edit_use_anchors_": false
-}
 
 [node name="DemoInterface" parent="." instance=ExtResource("9")]
+anchors_preset = 10
 
 [editable path="MainView/SubViewport/Scene"]

--- a/godot/Demos/BlurGlowDemo.tscn
+++ b/godot/Demos/BlurGlowDemo.tscn
@@ -42,9 +42,17 @@ script = ExtResource("1")
 
 [node name="MaskView" type="SubViewportContainer" parent="."]
 self_modulate = Color(1, 1, 1, 0)
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -960.0
+offset_top = -540.0
+offset_right = 960.0
+offset_bottom = 540.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 2
 stretch = true
 
@@ -85,13 +93,22 @@ render_target_update_mode = 4
 [node name="Sprite2D" type="Sprite2D" parent="MaskView/SubViewport/Blur2/SubViewport/Blur1/SubViewport"]
 material = SubResource("3")
 position = Vector2(960, 540)
+scale = Vector2(0.75, 0.75)
 texture = ExtResource("5_bxej1")
 
 [node name="MainView" type="SubViewportContainer" parent="."]
 material = SubResource("6")
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -960.0
+offset_top = -540.0
+offset_right = 960.0
+offset_bottom = 540.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 2
 stretch = true
 
@@ -105,7 +122,6 @@ render_target_update_mode = 4
 
 [node name="Sprite2D" parent="MainView/SubViewport/Scene" index="0"]
 position = Vector2(960, 540)
-scale = Vector2(1, 1)
 
 [node name="RemoteTransform2D" type="RemoteTransform2D" parent="MainView/SubViewport/Scene/Sprite2D" index="0"]
 remote_path = NodePath("../../../../../MaskView/SubViewport/Blur2/SubViewport/Blur1/SubViewport/Sprite2D")

--- a/godot/Demos/BlurGlowDemo.tscn
+++ b/godot/Demos/BlurGlowDemo.tscn
@@ -12,9 +12,11 @@
 
 [sub_resource type="ShaderMaterial" id="1"]
 shader = ExtResource("3")
+shader_parameter/blur_scale = Vector2(1, 1)
 
 [sub_resource type="ShaderMaterial" id="2"]
 shader = ExtResource("3")
+shader_parameter/blur_scale = Vector2(1, 1)
 
 [sub_resource type="ShaderMaterial" id="3"]
 shader = ExtResource("5")

--- a/godot/Demos/Glow2D/BlurGlow/Scene.tscn
+++ b/godot/Demos/Glow2D/BlurGlow/Scene.tscn
@@ -1,8 +1,10 @@
-[gd_scene format=3 uid="uid://dnei3uy5bhpha"]
+[gd_scene load_steps=2 format=3 uid="uid://dnei3uy5bhpha"]
+
+[ext_resource type="Texture2D" uid="uid://7giw201cbixu" path="res://Shared/sprites/robi_shaded.png" id="1_ocuod"]
 
 [node name="Scene" type="Node2D"]
 
 [node name="Sprite2D" type="Sprite2D" parent="."]
 position = Vector2(640, 360)
 scale = Vector2(0.75, 0.75)
-texture = null
+texture = ExtResource("1_ocuod")

--- a/godot/Shaders/gaussian_blur.gdshader
+++ b/godot/Shaders/gaussian_blur.gdshader
@@ -3,7 +3,6 @@ shader_type canvas_item;
 uniform vec2 blur_scale = vec2(1, 0);
 
 const float SAMPLES = 71.0;
-const float TAU = 6.283185307179586476925286766559;
 
 float gaussian(float x) {
 	float x_squared = x * x;
@@ -14,15 +13,15 @@ float gaussian(float x) {
 
 void fragment() {
 	vec2 scale = TEXTURE_PIXEL_SIZE * blur_scale;
-	
+
 	float total_weight = 0.0;
 	vec4 color = vec4(0.0);
-	
+
 	for (int i = -int(SAMPLES) / 2; i < int(SAMPLES) / 2; ++i) {
 		float weight = gaussian(float(i));
 		color += texture(TEXTURE, UV + scale * vec2(float(i))) * weight;
 		total_weight += weight;
 	}
-	
+
 	COLOR = color / total_weight;
 }

--- a/godot/Utils/DebugViewer.gd
+++ b/godot/Utils/DebugViewer.gd
@@ -28,7 +28,6 @@ func refresh_viewports() -> void:
 
 		_texture_rect.custom_minimum_size = Vector2(width, height)
 		_texture_rect.texture = viewport.get_texture()
-		_texture_rect.flip_v = true
 
 		vbox.add_child(_texture_rect)
 	add_child(vbox)


### PR DESCRIPTION
Per the [migration to Godot 4 tracker issue post ](https://github.com/gdquest-demos/godot-shaders/issues/53#issuecomment-2637610833) here is the fix for the blur glow shader.

Issues found (and fixed):

- Redeclaration of TAU constant in blur shader.
- Shader not flipping texture on y anymore.
- I am not fully sure exactly what, but the subviewports where not showing correctly in runtime, something to do with the size of the viewport not scaling as expected, whereas it was fine on the editor. Fix might not be proper but I just changed the anchors of the viewport container.